### PR TITLE
Make sure Github namespace is lowercase

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,10 +25,11 @@ sanitize "${IMAGE}" "image"
 sanitize "${TAG}" "tag"
 
 if [ "$REGISTRY" == "docker.pkg.github.com" ]; then
-    export IMAGE="$GITHUB_REPOSITORY/$IMAGE"
+    IMAGE_NAMESPACE="$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')"
+    export IMAGE="$IMAGE_NAMESPACE/$IMAGE"
 
     if [ ! -z $INPUT_CACHE_REGISTRY ]; then
-        export INPUT_CACHE_REGISTRY="$REGISTRY/$GITHUB_REPOSITORY/$INPUT_CACHE_REGISTRY"
+        export INPUT_CACHE_REGISTRY="$REGISTRY/$IMAGE_NAMESPACE/$INPUT_CACHE_REGISTRY"
     fi
 fi
 


### PR DESCRIPTION
The docker registry only allows lowercase tags, however, Github usernames can be uppercase. This meant that uploading to the Github Packages registry would fail for people like me.

As far as I understand this is only applicable to Github Packages since that is the only place where you have to add scope to the namespace, but if that's not the case it might be wise to abstract a `lowercase` method and use it in multiple places.